### PR TITLE
Adding _asyncTransfer after _safeMint

### DIFF
--- a/contracts/NFT.sol
+++ b/contracts/NFT.sol
@@ -31,6 +31,7 @@ contract NFT is ERC721, PullPayment, Ownable {
     currentTokenId.increment();
     uint256 newItemId = currentTokenId.current();
     _safeMint(recipient, newItemId);
+    _asyncTransfer(owner(), msg.value);
     return newItemId;
   }
 


### PR DESCRIPTION
Hi!

First of all, thank you for the tutorial! 😄

At part four, I believe that maybe it's missing the deposit of the values after (or before) minting.

I checked at the docs and found the `_asyncTransfer` ([link](https://docs.openzeppelin.com/contracts/4.x/api/security#PullPayment-_asyncTransfer-address-uint256-))  function which stores the value to the Escrow contract.

As I didn't find any example showing up the flow of using PullPayment, I ended up testing it in the tutorial and taking the opportunity to open this PR to know about your opinion and also make it clearer for me.

Many thanks!


